### PR TITLE
Potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r , err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/francescomiliani/ghas-bootcamp-jonthebeach2025/security/code-scanning/4](https://github.com/francescomiliani/ghas-bootcamp-jonthebeach2025/security/code-scanning/4)

To fix the issue, we should use parameterized queries instead of constructing the query string with `fmt.Sprintf`. Parameterized queries allow us to safely embed user-controlled data into the query by using placeholders (`?`) and passing the actual values as arguments to the `Exec` method. This approach ensures that the database driver properly escapes and sanitizes the inputs, preventing SQL injection.

Specifically:
1. Replace the `fmt.Sprintf` query construction with a query string that uses placeholders (`?`) for all user-controlled values.
2. Pass the user-controlled values as arguments to the `Exec` method of the prepared statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
